### PR TITLE
added manual flagging/unflagging; added basic download button

### DIFF
--- a/dwr/app/app.py
+++ b/dwr/app/app.py
@@ -1,10 +1,12 @@
 import sys
 import math
 import time
+import asyncio
 import inspect
-from pathlib import Path
-from functools import wraps
+from io import StringIO
 from pprint import pprint
+from pathlib import Path
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -17,6 +19,7 @@ from shinywidgets import output_widget, render_widget
 import shinyswatch
 
 import plotly.express as px
+import plotly.graph_objs as go
 
 import od
 import util
@@ -26,12 +29,12 @@ from util import print_func_name, jlog, jlog1, jlog2
 
 
 def req(variable):
-    util.req(variable, output_fn=jlog)
+    util.req(variable, output_fn=jlog1)
 
 app_ui = ui.page_sidebar(
             ui.sidebar(
                 #ui.output_image('logo'),
-                ui.p('Under construction'),
+                shinyswatch.theme_picker_ui(),
                 open='closed',
             ),
             ui.navset_pill(
@@ -58,9 +61,6 @@ app_ui = ui.page_sidebar(
                             ui.output_data_frame('staged_table'),
                         ),
                     ),
-                ),
-                ui.nav_panel('Clean',
-                    ui.p('Placeholder'),
                 ),
                 ui.nav_panel('Screen',
                     ui.row(
@@ -91,26 +91,45 @@ app_ui = ui.page_sidebar(
                                     multiple=True,
                                 ),
                                 ui.column(1,
-                                    ui.input_action_button('btn_od', 'Go', class_='btn-primary', style='height:90%; ')
+                                    ui.input_action_button('btn_od', 'Go', class_='btn-primary', style='height:90%;')
                                 ),
                             ),
                             ui.output_ui('od_function_inputs'),
                         ),
                         ui.column(7,
-                            output_widget('plot_data'),
+                            ui.row(
+                                ui.column(2),
+                                ui.column(4,
+                                    ui.input_action_button('btn_flag', 'Flag', class_='btn-danger', style='margin: 0 3px;'),
+                                    ui.input_action_button('btn_unflag', 'Unflag', class_='btn-success', style='margin: 0 3px;'),
+                                style='display:flex; justify-content: center'),
+                                ui.column(4,
+                                    ui.input_action_button('btn_undo_flag', 'Undo', class_='btn-light', style='margin: 0 3px;'),
+                                    ui.input_action_button('btn_redo_flag', 'Redo', class_='btn-light', style='margin: 0 3px;'),
+                                style='display:flex; justify-content: center'),
+                                ui.column(2),
+                            ),
+                            ui.row(
+                                output_widget('plot_data'),
+                            ),
                         ),
                     ),
                     ui.br(),
                 ),
                 ui.nav_spacer(),
+                ui.nav_control(
+                    ui.output_ui('show_download_button'),
+                ),
+                ui.nav_spacer(),
                 ui.nav_panel('Settings',
                     ui.br(),
-                    shinyswatch.theme_picker_ui(),
+                    ui.p('Under construction'),
                 ),
                 ui.nav_panel('Help',
                     ui.p('Placeholder'),
                 ),
             ),
+            ui.include_js('js/util.js'),
     #title='Tool', # takes up too much space
     window_title='Tool Prototype',
     theme=shinyswatch.theme.darkly, # default theme
@@ -129,6 +148,15 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Values just used in the 'visualize' page
     user_state = reactive.Value(app_state.State())
     active_df = reactive.Value(pd.DataFrame())
+
+    # List of currently selected points on a graph.
+    selected_points = []
+
+    # Lists of flagging operations, to support the undo/redo buttons.
+    # TODO: add undo size limit?
+    undo_stack = []
+    redo_stack = []
+
 
     @reactive.effect
     @print_func_name
@@ -230,17 +258,17 @@ def server(input: Inputs, output: Outputs, session: Session):
 
 
     @reactive.effect
-    @print_func_name
+    #@print_func_name
     def updateminmax():
         if not (y_col := input.sel_y()): #TODO: use req?
-            jlog1(f'no ycol')
+            #jlog1(f'no ycol')
             return
 
         df = active_df()
         req(df)
 
         # This happens when the file has been changed but the change hasn't
-        # propogated to the inputs yet
+        # propagated to the inputs yet
         if y_col not in df:
             jlog1(f'invalid col')
             return None
@@ -253,18 +281,16 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @reactive.effect
     @reactive.event(input.btn_od)
-    @print_func_name
+    @print_func_name('cyan')
     def do_outlier_detection():
-        df = active_df()
-        req(df)
+        req(df := active_df()) # not sure why this doesn't appear to need to be isolated
 
-        sel_od_fns = input.sel_od_functions()
-        req(sel_od_fns)
+        req(sel_od_fns := input.sel_od_functions())
 
-        x_col = input.sel_x()
-        req(x_col)
-        y_col = input.sel_y()
-        req(y_col)
+        req(x_col := input.sel_x())
+        req(y_col := input.sel_y())
+
+        req(selected_file := input.sel_files_viz())
 
         # Loop through all selected outlier detection methods and apply them serially
         for sel_od in sel_od_fns:
@@ -294,8 +320,11 @@ def server(input: Inputs, output: Outputs, session: Session):
 
             df[new_col_name] = od_info['fn'](**kwargs)
 
-            # Force invalidation by just changing the id
-            active_df.set(df.copy(deep=False))
+        # Force invalidation by changing (just) the id of active_df. We also have
+        # to keep the version of the df in the user's state in sync.
+        dfcp = df.copy(deep=False)
+        user_state().get_file(selected_file).df = dfcp
+        active_df.set(dfcp)
 
         return
 
@@ -335,13 +364,13 @@ def server(input: Inputs, output: Outputs, session: Session):
         return upload_df()
 
 
-    @render.data_frame
-    @print_func_name
-    def uploaded_table():
-        df = active_df()
-        if df is None:
-            return None
-        return df
+    #@render.data_frame
+    #@print_func_name
+    #def uploaded_table():
+    #    df = active_df()
+    #    if df is None:
+    #        return None
+    #    return df
 
 
     @render_widget
@@ -354,15 +383,12 @@ def server(input: Inputs, output: Outputs, session: Session):
         y_col = input.sel_y()
 
         if df.empty or not all([x_col, y_col]):
-            #jlog1('plot empty')
             return px.scatter()
 
         # This happens when the file input value has been changed but the change
         # hasn't propagated to the inputs yet
         if x_col not in df or y_col not in df:
-            #jlog1(f'invalid cols')
-            req(False) # better than returning since returning None will wipe out the graph
-            return None
+            req(False) # returning None will wipe out the graph
 
         jlog1(f'plot {x_col}/{y_col}')
         jlog1(f'{df[x_col].dtype}')
@@ -373,28 +399,240 @@ def server(input: Inputs, output: Outputs, session: Session):
         if od_cols := od.get_od_names(df, x_col, y_col):
             px_kwargs['color'] = px_kwargs['symbol'] = categ_name = 'Outlier Status'
 
-            df[categ_name] = df[od_cols].apply(util.get_first_true_column_name, axis=1)
+            df[categ_name] = df[od_cols].apply(util.get_true_first_column_name, axis=1)
             px_kwargs['category_orders'] = {
                 categ_name: [od.PASS] + od_cols # keep 'pass' first
             }
         jlog1(f'od_cols: {od_cols}')
-            
-        fig = px.scatter(
+
+        # This will allow us to correlate selected data points with "df"
+        df['idx'] = df.index
+
+        # We need the graph as a widget so we can register callbacks. It might end up
+        # being preferable to ditch plotly express and manually create the traces...
+        fig = go.FigureWidget(px.scatter(
             df,
-            #x=df[x_col],
             x=x_col,
             y=y_col,
+            custom_data='idx',
             **px_kwargs
-        )
+        ))
 
         od.prettify_column_names(fig, od_cols)
 
+        jlog1(f'{len(fig.data)} trace(s)')
+        for i, trace in enumerate(fig.data):
+            trace.on_selection(partial(gather_selection, trace_num=i))
+
+        fig.data[0].on_deselect(clear_selection) # only need to clear selections once
+
         return fig
+
+
+    # Note about callbacks: Plotly catches and completely ignores exceptions within
+    # callback functions. We catch and print them to make debugging possible.
+
+    # Each trace has a 0-indexed x and y list of values. Here, we use these
+    # indices to get the indices in the original DataFrame.
+    @util.catch_errors
+    @print_func_name
+    def gather_selection(trace, points, selector, trace_num: int) -> None:
+        nonlocal selected_points
+
+        jlog1(f'trace #{trace_num}: {trace.legendgroup}')
+
+        # The shape of customdata is a list of lists, each with 1 element. Get
+        # that 1 element for selected indices.
+        df_indices = trace.customdata[points.point_inds, 0]
+
+        if trace_num == 0:
+            selected_points = df_indices
+        else:
+            selected_points = np.append(selected_points, df_indices)
+
+        jlog1(selected_points)
+        jlog1()
+
+
+    # Prevent manual flagging buttons from doing anything when data is deselected
+    @util.catch_errors
+    @print_func_name
+    def clear_selection(trace, points) -> None:
+        nonlocal selected_points
+        selected_points = []
+
+
+    @print_func_name
+    def set_flags(indices: list, cols: list[str], value: bool|list[bool]) -> None:
+        req(selected_file := input.sel_files_viz())
+
+        jlog1(indices)
+        jlog1(cols)
+        if type(value) == bool:
+            jlog1(value)
+        else:
+            jlog1(list(value))
+
+        # We don't want this function to execute when active_df is changed
+        with reactive.isolate():
+            df = active_df()
+
+        df.loc[indices, cols] = value
+
+        #active_df.set(df.copy(deep=False))
+
+        # See comment in do_outlier_detection function
+        dfcp = df.copy(deep=False)
+        user_state().get_file(selected_file).df = dfcp
+        active_df.set(dfcp)
+
+    def manual_flag(value: bool) -> None:
+        req(selected_points)
+
+        with reactive.isolate():
+            df = active_df()
+
+        with reactive.isolate():
+            x_col = input.sel_x()
+            y_col = input.sel_y()
+        manual_y_col = od.get_manual_col(y_col)
+
+        if manual_y_col not in df:
+            df[manual_y_col] = False
+
+        if value:
+            target_cols = [manual_y_col]
+            new_values = [value for _ in selected_points]
+        else:
+            target_cols = od.get_od_names(df, x_col, y_col)
+            new_values = [tuple(value for _ in target_cols) for _ in selected_points]
+
+        prev_values = df.loc[selected_points, target_cols].copy()
+
+        # Save previous data to enable undos
+        undo_stack.append((selected_points, target_cols, prev_values, new_values))
+        emphasize_undo_button()
+
+        # Wipe out any possible redos
+        nonlocal redo_stack
+        redo_stack = []
+        unemphasize_redo_button()
+
+        set_flags(selected_points, target_cols, value)
+
+
+    @reactive.effect
+    @reactive.event(input.btn_flag)
+    def flag():
+        manual_flag(True)
+
+
+    @reactive.effect
+    @reactive.event(input.btn_unflag)
+    def unflag():
+        manual_flag(False)
+
+
+    @reactive.effect
+    @reactive.event(input.btn_undo_flag)
+    def undo_flag():
+        try:
+            sel, cols, prev, curr = undo_stack.pop()
+        except IndexError: # nothing to undo
+            return
+
+        redo_stack.append((sel, cols, prev, curr))
+        emphasize_redo_button()
+
+        if not undo_stack:
+            unemphasize_undo_button()
+
+        set_flags(sel, cols, prev)
+
+
+    @reactive.effect
+    @reactive.event(input.btn_redo_flag)
+    def redo_flag():
+        try:
+            sel, cols, prev, curr = redo_stack.pop()
+        except IndexError: # nothing to redo
+            return
+        undo_stack.append((sel, cols, prev, curr))
+        emphasize_undo_button()
+
+        if not redo_stack:
+            unemphasize_redo_button()
+
+        set_flags(sel, cols, curr)
+
+
+    @reactive.effect
+    @print_func_name('purple')
+    def react_to_new_selected_file():
+        req(selected_file := input.sel_files_viz())
+
+        # Clear stacks
+        nonlocal redo_stack, undo_stack
+        undo_stack = []
+        redo_stack = []
+        unemphasize_undo_button()
+        unemphasize_redo_button()
+
+        # Clear graph selection
+        nonlocal selected_points
+        selected_points = []
+
+
+    async def update_button_class(id, rm, add):
+        await session.send_custom_message(
+            'update_btn_class',
+            {
+                'id': id,
+                'rm': rm,
+                'add': add,
+            }
+        )
+        
+    def emphasize_undo_button():
+        asyncio.create_task(update_button_class('btn_undo_flag', 'btn-light', 'btn-warning'))
+    def unemphasize_undo_button():
+        asyncio.create_task(update_button_class('btn_undo_flag', 'btn-warning', 'btn-light'))
+    def emphasize_redo_button():
+        asyncio.create_task(update_button_class('btn_redo_flag', 'btn-light', 'btn-info'))
+    def unemphasize_redo_button():
+        asyncio.create_task(update_button_class('btn_redo_flag', 'btn-info', 'btn-light'))
+
+
+    @render.ui
+    def show_download_button():
+        selected_file = input.sel_files_viz()
+        req(selected_file)
+        selected_file = util.remove_suffix(selected_file)
+
+        # 0001f4be is another floppy disk option
+        return ui.download_button('download_data', f'\U0001f5ab {selected_file}', class_='btn-primary', style='width: auto; margin: 0 auto')
+
+
+    @render.download(
+        filename=lambda: f'{util.remove_suffix(input.sel_files_viz())}_screened.csv'
+    )
+    async def download_data():
+        df = active_df()
+        req(df)
+
+        buffer = StringIO()
+        df.to_csv(buffer, index=False)
+        buffer.seek(0)
+
+        for line in buffer:
+            yield line
 
     #@render.image
     #def logo():
     #    img: ImgData = {'src': 'img/logo.png', 'width': '100%'}
     #    return img
+
+
 
 
 app = App(app_ui, server, debug=False)

--- a/dwr/app/js/util.js
+++ b/dwr/app/js/util.js
@@ -1,0 +1,19 @@
+// Enable changing the class of an existing element (not natively supported in py shiny)
+Shiny.addCustomMessageHandler('update_btn_class', function(data) {
+    var btn = document.getElementById(data.id);
+    if (btn) {
+        btn.classList.remove(data.rm);
+        btn.classList.add(data.add);
+    }
+});
+
+
+// Set up keyboard shortcuts
+document.addEventListener('keydown', function(event) {
+    if (event.ctrlKey && event.key === 'z') {
+        document.getElementById('btn_undo_flag').click();
+    }
+    if (event.ctrlKey && event.key === 'y') {
+        document.getElementById('btn_redo_flag').click();
+    }
+});

--- a/dwr/app/od.py
+++ b/dwr/app/od.py
@@ -11,6 +11,8 @@ from pandas.api.types import is_datetime64_any_dtype
 # This is used to denote data that has not "failed" any outlier detection
 PASS = 'pass'
 
+MANUAL = 'manual_flag'
+
 DATE_STRS = [ # maybe rename this
     'days',
     'hours',
@@ -27,13 +29,29 @@ def get_od_name(x_col, y_col, test_name):
         return f'{x_col}_{y_col}{_F}{test_name}'
 
 
+def get_manual_col(y_col):
+    return f'{y_col}_{MANUAL}'
+
 # Help identify all columns that are the result of running outlier detection on a column
+# or manual flagging.
 def get_od_names(df, x_col, y_col):
-    return [col
+    ret = [col
         for col in df.columns
-        if get_od_name(x_col, y_col, '') in col or 
-           get_od_name(x_col, None, '') in col
+        if any((
+            get_od_name(x_col, y_col, '') in col,
+            get_od_name(x_col, None, '') in col,
+            get_manual_col(y_col) in col,
+        ))
     ]
+
+    # This feeds into how columns are sorted - we want manual flagging to appear first
+    #try:
+    #    idx = ret.index(MANUAL)
+    #    ret.insert(0, ret.pop(idx))
+    #except ValueError: # not found in list
+    #    pass
+
+    return ret
 
 
 # Help rename plotly elements so that they don't display our ugly internal column names.
@@ -43,7 +61,7 @@ def get_od_names(df, x_col, y_col):
 # markers (color & shape). That is what gets changed here.
 def prettify_column_names(figure, od_cols) -> None:
     renames = {
-        col: col[col.find(_F):].lstrip('_')
+        col: MANUAL if MANUAL in col else col[col.find(_F):].lstrip('_')
         for col in od_cols
     }
     if renames:

--- a/dwr/app/od.py
+++ b/dwr/app/od.py
@@ -143,6 +143,8 @@ the provided cadence, will be flagged as invalid.  Specifically, the value that
         raise ValueError('No input data.')
     if not is_datetime64_any_dtype(ts):
         raise ValueError('Input date column does not have a valid datetime data type.')
+    if unit not in DATE_STRS:
+        raise ValueError(f'Input date types must be one of: {DATE_STRS}.')
 
     cadence = pd.Timedelta(number, unit)
 

--- a/dwr/app/util.py
+++ b/dwr/app/util.py
@@ -2,8 +2,10 @@
 import html
 import dateutil
 import dateparser
+from pathlib import Path
 from functools import wraps
 
+import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
@@ -12,16 +14,44 @@ from shiny import ui
 
 LOG_MSG = 0
 
+COLORS = {
+    None: '\033[0m',
+    'red': '\033[31m',
+    'green': '\033[32m',
+    'yellow': '\033[33m',
+    'blue': '\033[34m',
+    'purple': '\033[35m',
+    'cyan': '\033[36m',
+}
+
 # TODO: increase level as call stack grows in depth
-def print_func_name(func):
+def print_func_name(color=None):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            key = None if callable(color) else color
+            jlog(f'{COLORS[key]}{func.__name__}\033[0m')
+            return func(*args, **kwargs)
+        return wrapper
+
+    # Allow calling without parentheses
+    if callable(color):
+        return decorator(color)
+    return decorator
+
+
+def catch_errors(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        jlog(f'{func.__name__}')
-        return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            print(f'ERROR: {func.__name__}: {e}')
+            return None
     return wrapper
 
 
-def jlog(msg, level=0):
+def jlog(msg='', level=0):
     print(f'JLO: {chr(9)*level}{msg}')
 
     global LOG_MSG
@@ -30,9 +60,9 @@ def jlog(msg, level=0):
         raise RuntimeError('something has gone wrong')
 
 
-def jlog1(msg):
+def jlog1(msg=''):
     return jlog(msg, level=1)
-def jlog2(msg):
+def jlog2(msg=''):
     return jlog(msg, level=2)
 
 
@@ -41,7 +71,9 @@ def jlog2(msg):
 # 2. Allow for outputting
 def req(variable, output_fn=print):
     if isinstance(variable, pd.DataFrame):
-        cond = not variable.empty # we don't support empty dataframes
+        cond = not variable.empty # we don't pass empty dataframes through
+    elif isinstance(variable, np.ndarray):
+        cond = variable.any()
     else:
         cond = variable
 
@@ -56,8 +88,11 @@ def to_html_list(items):
 
 # Returns the name of index in the input series with the first True value, or
 # None if none are True.
-def get_first_true_column_name(row: pd.Series) -> str:
+def get_true_first_column_name(row: pd.Series) -> str:
     if row.sum() > 0:
         return row.idxmax()
     else:
         return 'pass'
+
+def remove_suffix(filename):
+    return Path(filename).stem


### PR DESCRIPTION
Now seems like a good time to bucket some changes in before re-working the overall flow of things. 

Changes:
- Added flagging and unflagging as shown at the last demo. 
- Added download button. For now, it also downloads some columns that are internal to the tool.
- Misc cleanup/enhancements

Overall thoughts:
- `app.py` is growing to be pretty long. This isn't ideal, but shiny's model of using the global-type reactive variables doesn't lend itself well to breaking up the main file. I will continue to think about this.
- Type annotations and function docstrings are still very limited - it makes sense to save this activity for later phases of the project IMO, since things will continue to change and invalidate some prior efforts.