### PR TITLE
Make file format explicit

### DIFF
--- a/dwr/outlier_tool/app.py
+++ b/dwr/outlier_tool/app.py
@@ -27,7 +27,7 @@ from . import app_ui
 from . import util
 from . import app_state
 from . import upload_util
-from .util import print_func_name, jlog, jlog1, jlog2
+from .util import print_func_name, jlog, jlog1, jlog2, get_file_size
 
 
 def req(variable):
@@ -104,7 +104,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             refresh_od_results_manual(file_obj)
 
         except Exception as e:
-            util.show_danger(f'Internal error: {e}', duration=5)
+            util.show_error(f'Internal error: {e}', duration=5)
 
 
     @reactive.effect
@@ -115,25 +115,43 @@ def server(input: Inputs, output: Outputs, session: Session):
 
         fpath = file[0]['datapath'] # file path internal to browser, only used here
         fname = file[0]['name'] # file name used as unique key, used in many functions
+        fsize = get_file_size(fpath)
+        fsize_mb = round(fsize / 1_000_000, 1)
+
+        if fsize > m.MAX_FILE_SIZE_BYTES:
+            util.show_error(
+                f'File size ({fsize_mb} MB) exceeds maximum of {m.MAX_FILE_SIZE_MB} MB',
+                duration=None,
+            )
+            return
+        elif fsize > m.WARN_FILE_SIZE_BYTES:
+            util.show_warning(f'File sizes greater than {m.WARN_FILE_SIZE_MB} MB may cause performance issues.')
+            progress = ui.Progress(0, 3) # this needs to be closed before the function completes
+        else:
+            progress = None
 
         with reactive.isolate():
             selected_upload_options = input.upload_settings()
 
         # Load file
         try:
+            util.cond_progress(progress, 0, 'Reading file into python')
             df = upload_util.read_csv(fpath, selected_upload_options)
         except Exception as e:
             upload_msg.set(upload_util.format_upload_error_msg(fname, exception=e))
+            util.cond_progress.close()
             return
 
         msg_kw = {}
 
         # Preprocess data if needed
+        util.cond_progress(progress, 1, 'Running pre-processing')
         if 'upload_nullify_hyphens' in selected_upload_options:
             # operates inplace on df
             msg_kw['hyphen_fixed'], msg_kw['hyphen_attempted'] = upload_util.nullify_hyphens(df)
 
         # Register file with internal systems
+        util.cond_progress(progress, 2, 'Setting up tool internals')
         state = user_state()
         file_obj = state.add_file(fname, df)
         msg_kw['total_cols'] = len(file_obj.df.columns)
@@ -142,6 +160,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         msg_kw['composite_date_col'] = file_obj.composite_date_col
 
         # Make file available on all relevant tabs
+        util.cond_progress(progress, 3, 'Refreshing tool state')
         ui.update_select('sel_files_check', choices=state.get_filenames())
         ui.update_select('sel_files_test', choices=state.get_filenames())
         ui.update_select('sel_files_viz', choices=state.get_filenames())
@@ -172,6 +191,7 @@ def server(input: Inputs, output: Outputs, session: Session):
             **msg_kw
         ))
 
+        util.cond_progress_close(progress)
         jlog1(f'read_file exit')
 
 
@@ -768,7 +788,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         try:
             tests.remove_by_hash(int(hash_value))
         except Exception as e:
-            util.show_danger(f'Internal error: {e}')
+            util.show_error(f'Internal error: {e}')
             return
 
         if len(tests) == 0:

--- a/dwr/outlier_tool/app.py
+++ b/dwr/outlier_tool/app.py
@@ -20,14 +20,8 @@ import shinyswatch
 import plotly.express as px
 import plotly.graph_objs as go
 
-from . import m
-from . import od
-from . import od_ui
-from . import app_ui
-from . import util
-from . import app_state
-from . import upload_util
-from .util import print_func_name, jlog, jlog1, jlog2, get_file_size
+from . import m, od, od_ui, app_ui, util, app_state, upload_util, schema
+from .util import print_func_name, jlog, jlog1, jlog2
 
 
 def req(variable):
@@ -115,7 +109,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
         fpath = file[0]['datapath'] # file path internal to browser, only used here
         fname = file[0]['name'] # file name used as unique key, used in many functions
-        fsize = get_file_size(fpath)
+        fsize = util.get_file_size(fpath)
         fsize_mb = round(fsize / 1_000_000, 1)
 
         if fsize > m.MAX_FILE_SIZE_BYTES:
@@ -130,37 +124,39 @@ def server(input: Inputs, output: Outputs, session: Session):
         else:
             progress = None
 
+        # Read all upload settings
         with reactive.isolate():
-            selected_upload_options = input.upload_settings()
+            read_kwargs = {}
+            selected_ff = input.sel_file_format()
+
+            if not input.checkbox_data_has_header():
+                read_kwargs['header'] = None
+
+            if input.checkbox_skip_n_rows():
+                read_kwargs['skiprows'] = input.input_skip_n_rows()
 
         # Load file
         try:
             util.cond_progress(progress, 0, 'Reading file into python')
-            df = upload_util.read_csv(fpath, selected_upload_options)
+            df = upload_util.read_file(fpath, selected_ff, read_kwargs)
         except Exception as e:
             upload_msg.set(upload_util.format_upload_error_msg(fname, exception=e))
-            util.cond_progress.close()
+            util.cond_progress_close(progress)
             return
 
         msg_kw = {}
 
-        # Preprocess data if needed
-        util.cond_progress(progress, 1, 'Running pre-processing')
-        if 'upload_nullify_hyphens' in selected_upload_options:
-            # operates inplace on df
-            msg_kw['hyphen_fixed'], msg_kw['hyphen_attempted'] = upload_util.nullify_hyphens(df)
-
         # Register file with internal systems
-        util.cond_progress(progress, 2, 'Setting up tool internals')
+        util.cond_progress(progress, 1, 'Setting up tool internals')
         state = user_state()
-        file_obj = state.add_file(fname, df)
+        file_obj = state.add_file(fname, df, selected_ff)
         msg_kw['total_cols'] = len(file_obj.df.columns)
         msg_kw['num_date_cols'] = len(file_obj.date_cols)
         msg_kw['num_numeric_cols'] = len(file_obj.num_cols)
         msg_kw['composite_date_col'] = file_obj.composite_date_col
 
         # Make file available on all relevant tabs
-        util.cond_progress(progress, 3, 'Refreshing tool state')
+        util.cond_progress(progress, 2, 'Refreshing tool state')
         ui.update_select('sel_files_check', choices=state.get_filenames())
         ui.update_select('sel_files_test', choices=state.get_filenames())
         ui.update_select('sel_files_viz', choices=state.get_filenames())
@@ -174,10 +170,6 @@ def server(input: Inputs, output: Outputs, session: Session):
         # uploads, the resulting data may have different column names. If so, we need to
         # make sure to refresh a few tabs so that they don't display the previous column names.
         with reactive.isolate():
-            # Refresh "check_table"
-            if (selected_file := input.sel_files_check()) == fname:
-                invalidate_file_selector('sel_files_check')
-
             # Refresh test ui in test tab
             if (selected_file := input.sel_files_test()) == fname:
                 _initialize_test_ui(file_obj)
@@ -210,8 +202,30 @@ def server(input: Inputs, output: Outputs, session: Session):
 
 
     @render.ui
+    def file_format_info():
+        return schema.get_file_format_info(input.sel_file_format())
+        description, extended_description = schema.get_file_format_info(input.sel_file_format())
+        return (ui.p(description), ui.p(extended_description))
+
+
+    @render.ui
     def upload_text():
         return upload_msg()
+
+
+    @render.ui
+    def show_rows_to_skip():
+        req(input.checkbox_skip_n_rows())
+        return ui.input_numeric('input_skip_n_rows', 'Number of rows:', 0, min=0)
+
+
+    # Show upload options when no file format is selected
+    @render.ui
+    def upload_options():
+        req(ff := input.sel_file_format())
+        if ff != m.NO_FF:
+            return None
+        return app_ui.show_upload_options()
 
 
     def _update_x_cols(file_obj: app_state.File):
@@ -842,9 +856,10 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     # This is used to force execution of reactive events that depend on the input file
     # selector.
-    def invalidate_file_selector(sel_id):
-        with reactive.isolate():
-            req(selected_file := input[sel_id]())
+    def invalidate_file_selector(sel_id, selected_file=None):
+        if selected_file is None:
+            with reactive.isolate():
+                req(selected_file := input[sel_id]())
         ui.update_select(sel_id, selected='')
         ui.update_select(sel_id, selected=selected_file)
 

--- a/dwr/outlier_tool/app_state.py
+++ b/dwr/outlier_tool/app_state.py
@@ -59,7 +59,7 @@ class File():
         self.date_cols = upload_util.get_date_cols(self.df, self.empty_cols, self.schema)
         self.num_cols = upload_util.get_num_cols(self.df, self.empty_cols, self.schema)
 
-        # Coerce numeric/string columns to date columns
+        # Coerce numeric/string columns to date columns (this is a slow operation)
         for col in self.date_cols:
             # Inconsistent data can throw this operation off
             try:

--- a/dwr/outlier_tool/app_state.py
+++ b/dwr/outlier_tool/app_state.py
@@ -4,15 +4,15 @@ from shiny import ui
 from . import m
 from . import util
 from . import upload_util
-from .schema import find_matching_schema
+from .schema import get_schema
 
 # Tracks the state of a user's session
 class State():
     def __init__(self):
         self.files = {}
 
-    def add_file(self, fname, df):
-        self.files[fname] = File(fname, df)
+    def add_file(self, fname: str, df: pd.DataFrame, ff: str):
+        self.files[fname] = File(fname, df, ff)
         return self.get_file(fname)
 
     def get_file(self, fname):
@@ -24,7 +24,7 @@ class State():
 
 # Stores data needed for using an uploaded file
 class File():
-    def __init__(self, name, df):
+    def __init__(self, name, df, selected_ff):
         self.name = name
         self.df = df
         self.schema = None
@@ -35,24 +35,25 @@ class File():
 
 
         # Match schema to file if possible
-        if schema := find_matching_schema(self.name, self.df):
+        if schema := get_schema(selected_ff):
             self.schema = schema
 
-            # Update df column names with schema's column names if file had no header
-            if list(df.columns)[0] == 'col0':
-                # This is only ever needed when a user has uploaded a file more than once,
-                # while toggling the header checkbox.
-                self.schema.reset_column_names()
+            if self.schema.columns:
+                # Update df column names with schema's column names if file had no header
+                if list(df.columns)[0] == 'col0':
+                    # This is only ever needed when a user has uploaded a file more than once,
+                    # while toggling the header checkbox.
+                    self.schema.reset_column_names()
 
-                self.df.rename(
-                    {src: trg.name for src, trg in zip(df.columns, schema.columns)},
-                    axis='columns',
-                    inplace=True,
-                )
-            # Update schema column names to match what the file header is
-            else:
-                for df_col, schema_col in zip(self.df.columns, self.schema.columns):
-                    schema_col.name = df_col
+                    self.df.rename(
+                        {src: trg.name for src, trg in zip(df.columns, schema.columns)},
+                        axis='columns',
+                        inplace=True,
+                    )
+                # Update schema column names to match what the file header is
+                else:
+                    for df_col, schema_col in zip(self.df.columns, self.schema.columns):
+                        schema_col.name = df_col
 
 
         self.empty_cols = upload_util.get_empty_cols(self.df)

--- a/dwr/outlier_tool/app_ui.py
+++ b/dwr/outlier_tool/app_ui.py
@@ -7,6 +7,7 @@ import shinyswatch
 from . import m
 from . import od
 from . import util
+from . import schema
 from . import upload_util
 
 
@@ -165,6 +166,27 @@ def test_help_modal():
     )
 
 
+def show_upload_options():
+    return ui.div(
+        ui.input_checkbox(
+            'checkbox_data_has_header',
+            upload_util.checkbox_with_help(
+                'Count first row as header',
+                'Uncheck if uploaded file has no header at the top row.'
+            ),
+            value=True,
+        ),
+        ui.input_checkbox(
+            'checkbox_skip_n_rows',
+            upload_util.checkbox_with_help(
+                'Ignore rows',
+                'The number of rows specified will be ignored.'
+            )
+        ),
+        ui.output_ui('show_rows_to_skip'),
+    id='upload_options')
+
+
 app_ui = ui.page_sidebar(
             ui.sidebar(
                 #ui.output_image('logo'),
@@ -179,26 +201,26 @@ app_ui = ui.page_sidebar(
                     ui.row(
                         ui.column(4,
                             ui.panel_well(
-                                ui.input_file('file1', 'Import a file:', accept=['.csv', '.prn'], multiple=False),
-                                ui.input_checkbox_group(
-                                    'upload_settings',
-                                    'Actions on this file:',
-                                    {
-                                        'data_has_header': upload_util.checkbox_with_help(
-                                            'Count first row as header',
-                                            'Uncheck if uploaded file has no header at the top row.'
-                                        ),
-                                        'upload_nullify_hyphens': upload_util.checkbox_with_help(
-                                            'Treat hyphens as nulls',
-                                            'Update any values consisting of only hyphens (-) to contain no value. Then, attempt to convert any affected columns to a numeric type.'
-                                        ),
-                                    },
-                                    selected=[
-                                        'data_has_header',
-                                        'upload_nullify_hyphens',
-                                    ]
+                                ui.row(
+                                    ui.input_select('sel_file_format', 'Optional file format (see description \u2192):', [m.NO_FF] + schema.get_all_schema_names()),
+                                ),
+                                ui.row(
+                                    ui.input_file('file1', 'Import a file:', multiple=False),
+                                ),
+                                ui.row(
+                                    ui.output_ui('upload_options'),
                                 ),
                             id='upload_well'),
+                        ),
+                        ui.column(4,
+                            ui.panel_well(
+                                tags.h5('File formats'),
+                                ui.p('''If your data is in a format that we don't natively support,
+                                        choosing a file format can let us know how to parse your data.
+                                '''),
+                                ui.hr(),
+                                ui.output_ui('file_format_info'),
+                            style='height: 100%;'),
                         ),
                         ui.column(4,
                             ui.panel_well(
@@ -209,7 +231,7 @@ app_ui = ui.page_sidebar(
                                 ),
                             ),
                         ),
-                    ),
+                    style='display: flex; align-items: stretch;'),
                     ui.br(),
                     ui.row(
                         ui.column(8,
@@ -224,10 +246,10 @@ app_ui = ui.page_sidebar(
                 ),
                 ui.nav_panel('3. Test Data',
                     ui.row(
-                        ui.column(6, 
+                        ui.column(6,
                             tags.h4('Set up and run outlier tests', class_='tab-title'),
                         ),
-                        ui.column(6, 
+                        ui.column(6,
                             ui.input_action_button('btn_test_help', 'Test descriptions', class_='btn-info'),
                         style='display: flex; justify-content: right; align-items: center;'),
                     ),
@@ -241,16 +263,6 @@ app_ui = ui.page_sidebar(
                         ui.column(1),
                         ui.column(6,
                             ui.span('Selected tests (some may need additional input):'),
-                            #ui.input_radio_buttons(
-                            #    'selected_tests_radio',
-                            #    'Order by:',
-                            #    {
-                            #        'test_name': 'Test name',
-                            #        'x_col': 'Date column',
-                            #        'y_col': 'Numeric column',
-                            #    },
-                            #    inline=True
-                            #),
                         ),
                     ),
                     ui.row(
@@ -348,7 +360,7 @@ app_ui = ui.page_sidebar(
                             ),
                             ui.input_select('sel_export_format', 'File format:', ['.csv', '.xlsx']),
                         ),
-                        ui.column(4, 
+                        ui.column(4,
                             ui.input_text('text_export_custom_fname', 'Custom file name (optional):', ''),
                             ui.div(
                                 tags.label('Download:', for_='download_data', class_='control-label'),

--- a/dwr/outlier_tool/css/misc.css
+++ b/dwr/outlier_tool/css/misc.css
@@ -14,11 +14,21 @@
 .shiny-file-input-progress {
     overflow: visible;
     border-radius: 10px;
-    height: 80%;
+    height: 20%;
 }
 .shiny-file-input-progress .progress-bar {
     border-radius: 6px;
-    height: 80%;
+    height: 100%;
+}
+
+/* This div doesn't respect the padding of its parent container */
+#upload_options {
+    margin-left: 16px;
+}
+
+/* overwrite bootstrap's default margin of 16px, it's too much */
+#upload_options .form-group {
+    margin-bottom: 0px;
 }
 
 /* Add a little space between titles and their surrounding content */
@@ -30,6 +40,16 @@
 /* The upload box takes up too much horizontal space - manually limit it */
 #upload_well > .shiny-input-container {
     max-width: 20em;
+}
+
+/* Indent input objects so they look like they're part of the checkbox above */
+#show_rows_to_skip .form-group {
+    margin-left: 1.4em;
+}
+
+/* The number of rows should generally be a single digit, no need for this to be large */
+#input_skip_n_rows {
+    max-width: 4em;
 }
 
 /* Make trash icon color match text around it by default*/

--- a/dwr/outlier_tool/m.py
+++ b/dwr/outlier_tool/m.py
@@ -66,3 +66,10 @@ WINDOW_TITLE = 'Tool Prototype'
 
 DEFAULT_THEME = shinyswatch.theme.darkly
 
+# Threshold the tool can use to reject input files
+MAX_FILE_SIZE_BYTES = 30_000_000
+MAX_FILE_SIZE_MB = int(MAX_FILE_SIZE_BYTES / 1_000_000)
+
+# Threshold the tool can use to warn the user about performance issues
+WARN_FILE_SIZE_BYTES = 5_000_000
+WARN_FILE_SIZE_MB = int(WARN_FILE_SIZE_BYTES / 1_000_000)

--- a/dwr/outlier_tool/m.py
+++ b/dwr/outlier_tool/m.py
@@ -73,3 +73,6 @@ MAX_FILE_SIZE_MB = int(MAX_FILE_SIZE_BYTES / 1_000_000)
 # Threshold the tool can use to warn the user about performance issues
 WARN_FILE_SIZE_BYTES = 5_000_000
 WARN_FILE_SIZE_MB = int(WARN_FILE_SIZE_BYTES / 1_000_000)
+
+# Default option of file format selector
+NO_FF = 'None'

--- a/dwr/outlier_tool/schema.py
+++ b/dwr/outlier_tool/schema.py
@@ -47,9 +47,9 @@ class Column:
 class Schema:
     '''Class to hold information about a custom data schema.'''
     name: str
-    columns: list[Column]
+    columns: Optional[list[Column]]
     description: Optional[str] = ''
-    supported_extensions: Optional[list[str]] = None
+    file_format_description: Optional[str] = 'This file format has no description.'
 
     # Support list-type indexing
     def __getitem__(self, idx):
@@ -64,19 +64,15 @@ class Schema:
             return default_value
         raise ValueError(str(k))
 
-    # TODO: work with the grammar here - we don't want to imply that all extensions are supported if
-    #       the user doesn't specify a list of them.
-    def does_not_support_extension(self, extension):
-        return self.supported_extensions is not None and extension not in self.supported_extensions
-
     @classmethod
     def from_dict(cls, data: dict) -> 'Schema':
         '''Creates a Schema object from a dictionary (parsed JSON).'''
-        columns = [Column(**col) for col in data['columns']] # Unpack dict into Column constructor
+        columns = [Column(**col) for col in data.get('columns', {})] # Unpack dict into Column constructor
 
         return cls(
             name=data['name'],
             description=data.get('description', ''),
+            file_format_description=data.get('file_format_description', ''),
             columns=columns
         )
 
@@ -84,16 +80,9 @@ class Schema:
     @classmethod
     def from_file(cls, file_path: str | os.PathLike) -> 'Schema':
         '''Loads and parses a JSON file into a Schema instance.'''
-        try:
-            with open(file_path, 'r') as f:
-                data = json.load(f)
-            return cls.from_dict(data)
-        except FileNotFoundError:
-            print(f'ERROR: File not found: {file_path}')
-        except json.JSONDecodeError:
-            print(f'ERROR: Could not decode JSON from {file_path}')
-        except Exception as e:
-            print(f'ERROR: {e}')
+        with open(file_path, 'r') as f:
+            data = json.load(f)
+        return cls.from_dict(data)
 
     def reset_column_names(self):
         for col in self.columns:
@@ -109,26 +98,31 @@ def parse_schemas(loc=SCHEMA_DIR):
             if (fpath := Path(os.path.join(rootname, filename))).suffix == '.json'
         ]
     except Exception as e:
-        print(f'COULD NOT LOAD SCHEMAS: {e}')
+        print(f'COULD NOT LOAD SCHEMAS: {repr(e)}')
         return []
 
 
-# TODO: make smarter
-def find_matching_schema(file_name: str, df):
-    cols = df.columns
+def get_schema(name):
+    for s in SCHEMAS:
+        if s.name == name:
+            return s
+    return None
 
-    try:
-        # This should always return a string but we catch errors for safety
-        suffix = get_suffix(file_name).lower()
-    except AttributeError:
-        suffix = None
 
-    for schema in SCHEMAS:
-        if any([
-            schema.does_not_support_extension(suffix),
-            len(cols) != len(schema.columns)
-        ]):
-            continue
-        return schema
+def get_all_schema_names():
+    return [s.name for s in SCHEMAS]
+
+
+def get_file_format_info(name: str):
+    if schema := get_schema(name):
+        return schema.file_format_description
+    else:
+        return '''Currently, no file format is selected. Please ensure your uploaded file
+            contains either one header row followed by your data, or just your data rows
+            without a header. If you choose not to include a header, we'll create generic
+            column names for you to use.
+        '''
+
+
 
 SCHEMAS = parse_schemas()

--- a/dwr/outlier_tool/schemas/om.json
+++ b/dwr/outlier_tool/schemas/om.json
@@ -1,9 +1,7 @@
 {
     "name": "O&M",
     "description": "Data dictionary provided by Daniel Wisheropp from the O&M team",
-    "supported_extensions": [
-        "PRN"
-    ],
+    "file_format_description": "This is a comma-separated .PRN or .csv file without any header row. 14 columns are expected, though data columns can be null if a station doesn't collect a given dimension.",
     "columns": [
         {
             "name": "SITE_NAME",

--- a/dwr/outlier_tool/schemas/toa5.json
+++ b/dwr/outlier_tool/schemas/toa5.json
@@ -1,0 +1,5 @@
+{
+    "name": "TOA5",
+    "description": "TOA5 Campbell Scientific format. Documentation: https://help.campbellsci.com/loggernet-manual/ln_manual/campbell_scientific_file_formats/toa5.htm",
+    "file_format_description": "This is a comma-separated file. The table header will be read from the 2nd row. Rows 1, 3, and 4 will be ignored."
+}

--- a/dwr/outlier_tool/upload_util.py
+++ b/dwr/outlier_tool/upload_util.py
@@ -66,7 +66,6 @@ def get_num_cols(df, empty, schema: Schema=None):
     ])]
 
 
-# TODO: maybe consider allowing user to pass format string
 def try_parse_date(value, strict=False):
     # Attempt #1
     try:

--- a/dwr/outlier_tool/upload_util.py
+++ b/dwr/outlier_tool/upload_util.py
@@ -15,17 +15,34 @@ from .m import DATETIMECOL
 from .schema import Schema
 
 
-def read_csv(fpath, options):
-    header = 'infer' if 'data_has_header' in options else None
+# This supports other delimiters
+def read_csv_basic(fpath, kwargs):
+    df = pd.read_csv(fpath, **kwargs)
 
-    df = pd.read_csv(fpath, header=header)
-
-    if header is None:
+    if 'header' in kwargs and kwargs['header'] is None:
         df.rename(
             {col: f'col{i}' for i, col in enumerate(df.columns)},
             axis='columns',
             inplace=True,
         )
+    return df
+
+
+def read_toa(fpath):
+    return pd.read_csv(fpath, skiprows=[0, 2, 3], na_values='NAN')
+
+
+def read_om(fpath):
+    return read_csv_basic(fpath, {'header': None})
+
+
+def read_file(fpath, selected_ff, kwargs):
+    if selected_ff == 'O&M':
+        df = read_om(fpath)
+    elif selected_ff == 'TOA5':
+        df = read_toa(fpath)
+    else:
+        df = read_csv_basic(fpath, kwargs)
 
     return df
 
@@ -43,7 +60,8 @@ def get_date_cols(df, empty, schema: Schema=None):
         # Columns should be valid dates if any of the conditions are true:
         if any((
             'date' in col.lower(),
-            schema is not None and schema[i].is_datetime(),
+            'time' in col.lower(),
+            schema is not None and len(schema.columns) > 0 and schema[i].is_datetime(),
         )):
             ret.append(col)
             continue
@@ -62,11 +80,14 @@ def get_num_cols(df, empty, schema: Schema=None):
         col not in empty,
 
         # Check if the column isn't manually labeled as non-numeric
-        schema is None or schema[i].is_numeric()
+        schema is None or len(schema.columns) == 0 or schema[i].is_numeric()
     ])]
 
 
 def try_parse_date(value, strict=False):
+    if pd.isna(value):
+        return None
+
     # Attempt #1
     try:
         parsed = dateutil.parser.parse(value)
@@ -185,16 +206,21 @@ def attempt_composite_date(df, sample_size=10) -> tuple[str | None, str | None, 
     return None, None, None
 
 
-def checkbox_with_help(description, tooltip_text):
+def text_with_help(description, tooltip_text, leading_text=''):
     return ui.TagList(
         ui.span(
-            ui.HTML(f'&nbsp;{description}&nbsp;')
+            ui.HTML(f'{leading_text}{description}&nbsp;')
         ),
         ui.tooltip(
             ui.span('\u2139'),
             tooltip_text
         ),
     )
+
+
+def checkbox_with_help(description, tooltip_text, leading_text=''):
+    # This adds a space between the checkbox and the text
+    return text_with_help(description, tooltip_text, leading_text='&nbsp;')
 
 
 # Returns ui elements that show the error status of a file upload+parse
@@ -210,8 +236,6 @@ def format_upload_msg(fname,
                       total_cols: int,
                       num_date_cols: int,
                       num_numeric_cols: int,
-                      hyphen_fixed=[],
-                      hyphen_attempted=[],
                       composite_date_col=None,
     ):
     elements = []
@@ -235,19 +259,6 @@ def format_upload_msg(fname,
 
     if composite_date_col:
         elements.append(util.info(f'"{composite_date_col}" was programmatically generated and added to the table.'))
-
-    # Hyphen conversion info
-    if hyphen_fixed:
-        elements.extend([
-            util.info(f'INFO: successfully converted to numeric type after deleting hyphens:'),
-            ui.HTML(to_html_list(hyphen_fixed)),
-        ])
-
-    if hyphen_attempted:
-        elements.extend([
-            util.warning(f'WARNING: deleting hyphens worked but there are still non-numeric values present:'),
-            ui.HTML(to_html_list(hyphen_attempted)),
-        ])
 
     # Add warning if there are missing columns
     missing_col_types = None

--- a/dwr/outlier_tool/util.py
+++ b/dwr/outlier_tool/util.py
@@ -91,8 +91,20 @@ def show_info(msg: TagChild, duration=3):
     ui.notification_show(msg, duration=duration, type='info')
 def show_warning(msg: TagChild, duration=3):
     ui.notification_show(msg, duration=duration, type='warning')
-def show_danger(msg: TagChild, duration=3):
-    ui.notification_show(msg, duration=duration, type='danger')
+def show_error(msg: TagChild, duration=3):
+    ui.notification_show(msg, duration=duration, type='error')
+
+
+def cond_progress(progress_bar, value, msg, detail=None):
+    if progress_bar is None:
+        return
+    progress_bar.set(value, message=msg, detail=detail)
+
+
+def cond_progress_close(progress_bar):
+    if progress_bar is None:
+        return
+    progress_bar.close()
 
 
 def to_html_list(items):
@@ -120,3 +132,7 @@ def get_suffix(filename):
 
 def remove_suffix(filename):
     return Path(filename).stem
+
+
+def get_file_size(filename):
+    return Path(filename).stat().st_size


### PR DESCRIPTION
Addresses the following issues in #32
- "has additional rows around headers (Andrew)"
- "Large file (David)"
- "Issues with several file formats (Nathan)"
- "Info above column headers (Alicia)"

Does *not* address the "long" data format. I recommend a more normalized tabular format for those users.

Changes made:
- Added "file format" selector. No file format selected by default, this matches the prior behavior.
- Tool supports the [TOA5 ](https://help.campbellsci.com/loggernet-manual/ln_manual/campbell_scientific_file_formats/toa5.htm)file format now (this is what Andrew + Nathan were using)
- Data schemas are now linked to file format and are no longer applied behind the scenes
- Added warning and error related to file sizes. Also added a progress bar when processing files (this happens after the upload) so the user isn't confused when nothing happens after uploading a larger file.
- Removed hyphen nullification code, I don't think it was ever used
- Added 'skip rows' config to skip N rows before processing the table