### PR TITLE
Indicate when tests do not require arguments

### DIFF
--- a/dwr/outlier_tool/app_ui.py
+++ b/dwr/outlier_tool/app_ui.py
@@ -206,6 +206,7 @@ app_ui = ui.page_sidebar(
         shinyswatch.theme_picker_ui(),
         open='closed',
     ),
+    ui.head_content(tags.link(rel='icon', href=m.FAVICON_URL, type='image/x-icon')),
     ui.navset_pill(
         ui.nav_panel(
             '1. Import',

--- a/dwr/outlier_tool/m.py
+++ b/dwr/outlier_tool/m.py
@@ -87,3 +87,6 @@ NO_FF = 'None'
 
 # Minimum test duration - tests faster than this will be delayed for visual effect
 MIN_DUR = 0.2
+
+# URL to use for tool's favicon
+FAVICON_URL = 'https://water.ca.gov/favicon.ico'

--- a/dwr/outlier_tool/od_ui.py
+++ b/dwr/outlier_tool/od_ui.py
@@ -105,7 +105,9 @@ class ODTestSet:
             inputs = []
             if 'args' not in od.OD_IMPLEMENTED[test.test_key]:
                 inputs.append(ui.p('No additional arguments needed.'))
+                emoji = ui.tooltip('\u2705', 'No test configuration needed', placement='top')
             else:
+                emoji = ui.tooltip('\u25b6', 'Test configuration may be needed', placement='top')
                 for arg_id, arg_label, arg_type, default_value in od.OD_IMPLEMENTED[test.test_key]['args']:
                     # Create unique identifier of this argument so we can search for it later
                     input_id = f'{test.test_key}_{test.test_col.replace(" ", "_")}_{arg_id}'
@@ -129,18 +131,21 @@ class ODTestSet:
             # also uniquely identify accordion panels.
             value = str(hash(test))
 
-            plain_name = od.OD_IMPLEMENTED[test.test_key]['plain']
             col_widths = od.OD_IMPLEMENTED[test.test_key].get('col_widths', None)
-            title = f'{plain_name}: {test.test_col}'
+            plain_name = ui.strong(od.OD_IMPLEMENTED[test.test_key]['plain'])
+            title = ui.HTML(f'{plain_name}: {test.test_col}')
 
             accordions.append(
                 ui.accordion_panel(
                     title,
                     ui.layout_columns(*inputs, col_widths=col_widths),
                     icon=ui.tags.span(
-                        ui.HTML(trash_svg),
-                        class_='clickable-accordion-trash-icon',
-                        data_panel_value=value,  # this becomes data-panel-value in the browser
+                        ui.tags.span(
+                            ui.HTML(trash_svg),
+                            class_='clickable-accordion-trash-icon',
+                            data_panel_value=value,  # this becomes data-panel-value in the browser
+                        ),
+                        ui.tags.span(emoji),
                     ),
                     value=value,
                 )


### PR DESCRIPTION
Fixes #38 

<img width="545" height="423" alt="image" src="https://github.com/user-attachments/assets/c5ca5707-37ce-4097-8855-4d061312050f" />


Some thoughts:
1. I avoided adding more text to the accordion titles like "(does not require arguments)". It ended up adding too much clutter, IMO.
2. Adding an emoji to the right-hand-side of the title didn't look great
3. Adding just a checkmark emoji looked wrong so I added the play emoji
4. It's technically possible to make the emoji dynamic, ie when the user inputs arguments the emoji turns green. I don't like this, however, because it would significantly increase server interactions and also might give the false impression that the arguments are valid or correct

This PR has a bonus commit of including DWR's favicon - I got tired of not having one!